### PR TITLE
Rename and reformat the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,80 +1,79 @@
+dnslib
+------
 
-    dnslib
-    ------
+A library to encode/decode DNS wire-format packets supporting both 
+Python 2.7 and Python 3.2+.
 
-    A library to encode/decode DNS wire-format packets supporting both 
-    Python 2.7 and Python 3.2+.
+The library provides:
 
-    The library provides:
+ * Support for encoding/decoding DNS packets between wire format,
+    python objects, and Zone/DiG textual representation (dnslib.dns)
 
-        * Support for encoding/decoding DNS packets between wire format,
-          python objects, and Zone/DiG textual representation (dnslib.dns)
+ * A server framework allowing the simple creation of custom DNS 
+    resolvers (dnslib.server) and a number of example servers 
+    created using this frameowork
 
-        * A server framework allowing the simple creation of custom DNS 
-          resolvers (dnslib.server) and a number of example servers 
-          created using this frameowork
+ * A number of utilities for testing (dnslib.client, dnslib.proxy,
+    dnslib.intercept)
 
-        * A number of utilities for testing (dnslib.client, dnslib.proxy,
-          dnslib.intercept)
+Python 3 support was added in Version 0.9.0 which represented a fairly
+major update to the library - the key changes include:
 
-    Python 3 support was added in Version 0.9.0 which represented a fairly
-    major update to the library - the key changes include:
+ * Python 2.7/3.2+ support (the last version supporting Python 2.6 
+    or earlier was version 0.8.3)
 
-        * Python 2.7/3.2+ support (the last version supporting Python 2.6 
-          or earlier was version 0.8.3)
+ * Support for encoding/decoding resource records in 'Zone' (BIND) 
+    file format 
 
-        * Support for encoding/decoding resource records in 'Zone' (BIND) 
-          file format 
+ * Support for encoding/decoding backets in 'DiG' format
 
-        * Support for encoding/decoding backets in 'DiG' format
+ * Server framework allowing (in most cases) custom resolvers to
+    be created by just subclassing the DNSResolver class and 
+    overringing the 'resolve' method
 
-        * Server framework allowing (in most cases) custom resolvers to
-          be created by just subclassing the DNSResolver class and 
-          overringing the 'resolve' method
+ * A lot of fixes to error detection/handling which should make 
+    the library much more robust to invalid/unsupported data. The
+    library should now either return a valid DNSRecord instance
+    or raise DNSError (tested via fuzzing)
 
-        * A lot of fixes to error detection/handling which should make 
-          the library much more robust to invalid/unsupported data. The
-          library should now either return a valid DNSRecord instance
-          or raise DNSError (tested via fuzzing)
+ * Improved utilities (dnslib.client, dnslib.proxy, dnslib.intercept)
 
-        * Improved utilities (dnslib.client, dnslib.proxy, dnslib.intercept)
+ * Improvements to encoding/decoding tests including the ability
+    to generate test data automatically in test_decode.py (comparing
+    outputs against DiG)
 
-        * Improvements to encoding/decoding tests including the ability
-          to generate test data automatically in test_decode.py (comparing
-          outputs against DiG)
+ * Ability to compare and diff DNSRecords
 
-        * Ability to compare and diff DNSRecords
+This is a large release and despite the testing there therefore are likely
+to be some bugs. Once the 0.9 release is sufficiently stable I would expect
+to release as 1.0.0 (and stabilise th api)
 
-    This is a large release and despite the testing there therefore are likely
-    to be some bugs. Once the 0.9 release is sufficiently stable I would expect
-    to release as 1.0.0 (and stabilise th api)
-    
-    The key DNS packet handling classes are in dnslib.dns and map to the 
-    standard DNS packet sections:
+The key DNS packet handling classes are in dnslib.dns and map to the 
+standard DNS packet sections:
 
-        * DNSRecord - container for DNS packet. Contains:
-            - DNSHeader 
-            - Question section containing zero or more DNSQuestion objects 
-            - Answer section containing zero or more RR objects 
-            - Authority section containing zero or more RR objects 
-            - Additional section containing zero or more RR objects 
-        * DNS RRs (resource records) contain an RR header and an RD object)
-        * Specific RD types are implemented as subclasses of RD
-        * DNS labels are represented by a DNSLabel class - in most cases
-          this handles conversion to/from textual representation however
-          does support arbitatry labels via a tuple of bytes objects)
+ * DNSRecord - container for DNS packet. Contains:
+    - DNSHeader 
+    - Question section containing zero or more DNSQuestion objects 
+    - Answer section containing zero or more RR objects 
+    - Authority section containing zero or more RR objects 
+    - Additional section containing zero or more RR objects 
+ * DNS RRs (resource records) contain an RR header and an RD object)
+ * Specific RD types are implemented as subclasses of RD
+ * DNS labels are represented by a DNSLabel class - in most cases
+    this handles conversion to/from textual representation however
+    does support arbitatry labels via a tuple of bytes objects)
 
-    Version 0.9 of the library was a major rewrite to support Python 3.2+ 
-    (retaining support for Python 2.7+). As part of the Py3 changes a 
-    number of other significant changes were intrtoduced:
+Version 0.9 of the library was a major rewrite to support Python 3.2+ 
+(retaining support for Python 2.7+). As part of the Py3 changes a 
+number of other significant changes were intrtoduced:
 
-    - Much better error handling (packet decoding errors should be 
-      caught and DNSError raised)
+- Much better error handling (packet decoding errors should be 
+    caught and DNSError raised)
 
-    Usage:
-    ------
+Usage:
+------
 
-    To decode a DNS packet:
+To decode a DNS packet:
 
     >>> packet = binascii.unhexlify(b'd5ad818000010005000000000377777706676f6f676c6503636f6d0000010001c00c0005000100000005000803777777016cc010c02c0001000100000005000442f95b68c02c0001000100000005000442f95b63c02c0001000100000005000442f95b67c02c0001000100000005000442f95b93')
     >>> d = DNSRecord.parse(packet)
@@ -87,7 +86,7 @@
     <DNS RR: 'www.l.google.com.' rtype=A rclass=IN ttl=5 rdata='66.249.91.103'>
     <DNS RR: 'www.l.google.com.' rtype=A rclass=IN ttl=5 rdata='66.249.91.147'>
 
-    The default text representation of the DNSRecord is in zone file format:
+The default text representation of the DNSRecord is in zone file format:
 
     >>> print(d)
     ;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 54701
@@ -101,11 +100,11 @@
     www.l.google.com.       5       IN      A       66.249.91.103
     www.l.google.com.       5       IN      A       66.249.91.147
 
-    To create a DNS Request Packet:
+To create a DNS Request Packet:
 
     >>> d = DNSRecord.question("google.com")
 
-    (This is equivalent to: d = DNSRecord(q=DNSQuestion("google.com") )
+(This is equivalent to: d = DNSRecord(q=DNSQuestion("google.com") )
 
     >>> d
     <DNS Header: id=... type=QUERY opcode=QUERY flags=RD rcode='NOERROR' q=1 a=0 ns=0 ar=0>
@@ -122,7 +121,7 @@
 
     >>> d = DNSRecord.question("google.com","MX")
 
-    (This is equivalent to: d = DNSRecord(q=DNSQuestion("google.com",QTYPE.MX) )
+(This is equivalent to: d = DNSRecord(q=DNSQuestion("google.com",QTYPE.MX) )
 
     >>> str(DNSRecord.parse(d.pack())) == str(d)
     True
@@ -133,7 +132,7 @@
     ;; QUESTION SECTION:
     ;google.com.                    IN      MX
 
-    To create a DNS Response Packet:
+To create a DNS Response Packet:
 
     >>> d = DNSRecord(DNSHeader(qr=1,aa=1,ra=1),
     ...               q=DNSQuestion("abc.com"),
@@ -153,13 +152,13 @@
     ;; ANSWER SECTION:
     abc.com.                0       IN      A       1.2.3.4
 
-    It is also possible to create RRs from a string in zone file format
+It is also possible to create RRs from a string in zone file format
 
     >>> RR.fromZone("abc.com IN A 1.2.3.4")
     [<DNS RR: 'abc.com.' rtype=A rclass=IN ttl=0 rdata='1.2.3.4'>]
 
-    (Note: this produces a list of RRs which should be unpacked if being
-     passed to add_answer/add_auth/add_ar etc)
+(Note: this produces a list of RRs which should be unpacked if being
+    passed to add_answer/add_auth/add_ar etc)
 
     >>> q = DNSRecord.question("abc.com")
     >>> a = q.reply()
@@ -171,9 +170,9 @@
     ;abc.com.                       IN      A
     ;; ANSWER SECTION:
     abc.com.                60      IN      A       1.2.3.4
-    
-    The zone file can contain multiple entries and supports most of the normal
-    format defined in RFC1035 (specifically not $INCLUDE)
+
+The zone file can contain multiple entries and supports most of the normal
+format defined in RFC1035 (specifically not $INCLUDE)
 
     >>> z = '''
     ...         $TTL 300
@@ -191,7 +190,7 @@
     www.abc.com.            300     IN      TXT     "Some Text"
     mail.abc.com.           300     IN      CNAME   www.abc.com.
 
-    To create a skeleton reply to a DNS query:
+To create a skeleton reply to a DNS query:
 
     >>> q = DNSRecord(q=DNSQuestion("abc.com",QTYPE.ANY)) 
     >>> a = q.reply()
@@ -206,7 +205,7 @@
     ;; ANSWER SECTION:
     abc.com.                60      IN      A       1.2.3.4
 
-    Add additional RRs:
+Add additional RRs:
 
     >>> a.add_answer(RR("xxx.abc.com",QTYPE.A,rdata=A("1.2.3.4")))
     >>> a.add_answer(RR("xxx.abc.com",QTYPE.AAAA,rdata=AAAA("1234:5678::1")))
@@ -223,7 +222,7 @@
     xxx.abc.com.            0       IN      AAAA    1234:5678::1
 
 
-    It is also possible to create a reply from a string in zone file format:
+It is also possible to create a reply from a string in zone file format:
 
     >>> q = DNSRecord(q=DNSQuestion("abc.com",QTYPE.ANY)) 
     >>> a = q.replyZone("abc.com 60 IN CNAME xxx.abc.com")
@@ -252,62 +251,65 @@
     mail.abc.com.           300     IN      CNAME   www.abc.com.
 
 
-    The library also includes a simple framework for generating custom DNS
-    resolvers in dnslib.server (see module docs). In post cases this just 
-    requires implementing a custom 'resolve' method which receives a question 
-    object and returns a response.
+The library also includes a simple framework for generating custom DNS
+resolvers in dnslib.server (see module docs). In post cases this just 
+requires implementing a custom 'resolve' method which receives a question 
+object and returns a response.
 
-    A number of sample resolvers are provided as examples (see CLI --help):
+A number of sample resolvers are provided as examples (see CLI --help):
 
-        dnslib.fixedresolver    - Respond to all requests with fixed response
-        dnslib.zoneresolver     - Respond from Zone file 
-        dnslib.shellresolver    - Call shell script to generate response
+ * dnslib.fixedresolver    - Respond to all requests with fixed response
+ * dnslib.zoneresolver     - Respond from Zone file 
+ * dnslib.shellresolver    - Call shell script to generate response
 
-    The library includes a number of client utilities which can be run using:
+The library includes a number of client utilities which can be run using:
 
-        DiG like client library 
-        # python -m dnslib.client --help  
+ * DiG like client library 
 
-        DNS Proxy Server
+        # python -m dnslib.client --help
+
+ * DNS Proxy Server
+
         # python -m dnslib.proxy --help
 
-        Intercepting DNS Proxy Server (replace proxy responses for specified domains)
+ * Intercepting DNS Proxy Server (replace proxy responses for specified domains)
+
         # python -m dnslib.intercept --help
 
 
-    Changelog:
-    ----------
+Changelog:
+----------
 
-        *   0.1     2010-09-19  Initial Release
-        *   0.2     2010-09-22  Minor fixes
-        *   0.3     2010-10-02  Add DNSLabel class to support arbitrary labels (embedded '.')
-        *   0.4     2012-02-26  Merge with dbslib-circuits
-        *   0.5     2012-09-13  Add support for RFC2136 DDNS updates
-                                Patch provided by Wesley Shields <wxs@FreeBSD.org> - thanks
-        *   0.6     2012-10-20  Basic AAAA support
-        *   0.7     2012-10-20  Add initial EDNS0 support (untested)
-        *   0.8     2012-11-04  Add support for NAPTR, Authority RR and additional RR
-                                Patch provided by Stefan Andersson (https://bitbucket.org/norox) - thanks
-        *   0.8.1   2012-11-05  Added NAPTR test case and fixed logic error
-                                Patch provided by Stefan Andersson (https://bitbucket.org/norox) - thanks
-        *   0.8.2   2012-11-11  Patch to fix IPv6 formatting
-                                Patch provided by Torbjörn Lönnemark (https://bitbucket.org/tobbezz) - thanks
-        *   0.8.3   2013-04-27  Don't parse rdata if rdlength is 0
-                                Patch provided by Wesley Shields <wxs@FreeBSD.org> - thanks
-        *   0.9.0   2014-05-05  Major update including Py3 support (see docs)
+ *   0.1     2010-09-19  Initial Release
+ *   0.2     2010-09-22  Minor fixes
+ *   0.3     2010-10-02  Add DNSLabel class to support arbitrary labels (embedded '.')
+ *   0.4     2012-02-26  Merge with dbslib-circuits
+ *   0.5     2012-09-13  Add support for RFC2136 DDNS updates
+                        Patch provided by Wesley Shields <wxs@FreeBSD.org> - thanks
+ *   0.6     2012-10-20  Basic AAAA support
+ *   0.7     2012-10-20  Add initial EDNS0 support (untested)
+ *   0.8     2012-11-04  Add support for NAPTR, Authority RR and additional RR
+                        Patch provided by Stefan Andersson (https://bitbucket.org/norox) - thanks
+ *   0.8.1   2012-11-05  Added NAPTR test case and fixed logic error
+                        Patch provided by Stefan Andersson (https://bitbucket.org/norox) - thanks
+ *   0.8.2   2012-11-11  Patch to fix IPv6 formatting
+                        Patch provided by Torbjörn Lönnemark (https://bitbucket.org/tobbezz) - thanks
+ *   0.8.3   2013-04-27  Don't parse rdata if rdlength is 0
+                        Patch provided by Wesley Shields <wxs@FreeBSD.org> - thanks
+ *   0.9.0   2014-05-05  Major update including Py3 support (see docs)
 
-    License:
-    --------
+License:
+--------
 
-        *   BSD
+BSD
 
-    Author:
-    -------
+Author:
+-------
 
-        *   Paul Chakravarti (paul.chakravarti@gmail.com)
+ *   Paul Chakravarti (paul.chakravarti@gmail.com)
 
-    Master Repository/Issues:
-    -------------------------
+Master Repository/Issues:
+-------------------------
 
-        *   https://bitbucket.org/paulc/dnslib
-            (Cloned on GitHub: https://github.com/paulchakravarti/dnslib)
+ *   https://bitbucket.org/paulc/dnslib
+    (Cloned on GitHub: https://github.com/paulchakravarti/dnslib)


### PR DESCRIPTION
It should be correctly formatted within github _and_ bitbucket now.

Just had to touch it up in a couple of places, mainly to make the lists
format correctly.

You can review this on my fork page for this [project and branch](https://github.com/matthewfranglen/dnslib/tree/feature/README.md). It looks very nice!
